### PR TITLE
Corrected error in migration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,17 @@ __Optionally__ add the facade to your aliases:
 ]
 ```
 
-Perform the migration to create the database tables:
+If you are using Laravel 4.0 ,perform the migration to create the database tables:
 
 ```
 php artisan migrate --package=cossou/eventcron
+```
+
+Or if you are using Laravel 4.1, publish the package migration to your application
+
+```
+php artisan migrate:publish cossou/eventcron
+php artisan migrate
 ```
 
 

--- a/src/migrations/2014_02_09_171059_cossou_eventcron_create_base_table.php
+++ b/src/migrations/2014_02_09_171059_cossou_eventcron_create_base_table.php
@@ -1,6 +1,5 @@
 <?php
 
-use Doctrine\DBAL\Schema\Schema;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 


### PR DESCRIPTION
Here is the fix for issue #2, tested working in Laravel 4.1, I don't know about Laravel 4 as I have not tested, but I believe it's the same.

I also modified the readme to explain how Laravel 4.1 users can take advantage of the new migrate:publish command that publish the package migration file to your migration folder, as explained in laravel/framework#2232
